### PR TITLE
Use react bindings for TextField & CheckboxField

### DIFF
--- a/examples/simple-form/index.jsx
+++ b/examples/simple-form/index.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { Formik, Form } from 'formik';
 import {
   TextField,
+  CheckboxField,
   DebuggerView,
 } from '@department-of-veterans-affairs/formulate';
 
@@ -17,9 +18,10 @@ const App = () => (
     style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}
   >
     <h1>Example form</h1>
-    <Formik initialValues={{ foo: '' }}>
+    <Formik initialValues={{ foo: '', bar: true }}>
       <Form>
         <TextField name="foo" label="Example" required />
+        <CheckboxField name="bar" label="Do you have pets?" required />
         <DebuggerView />
       </Form>
     </Formik>

--- a/src/form-builder/CheckboxField.tsx
+++ b/src/form-builder/CheckboxField.tsx
@@ -1,60 +1,32 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
 
 import { FieldProps } from './types';
-import { getMessage } from '../utils/i18n';
+import { validator } from '../utils/validation';
+import { VaCheckbox } from 'web-components/react-bindings';
 
 type CheckboxProps = FieldProps<string> & { checked: boolean };
 
-// TODO: Figure out how to actually import the type defintions for these web components
-// The @ts-ignore comments are because the web component types aren't available.
-const Wrapper = (props: CheckboxProps) => {
-  const [field, meta, helpers] = useField(props as FieldHookConfig<boolean>);
+const CheckboxField = (props: CheckboxProps): JSX.Element => {
+  const withValidation = { ...props, validate: validator(props) };
+  const [field, meta, helpers] = useField(
+    withValidation as FieldHookConfig<boolean>
+  );
+  const id = props.id || props.name;
+  console.log(field);
 
-  // TODO: Use the web component type
-  const ref = useRef<HTMLElement>(null);
-  useEffect(() => {
-    // @ts-ignore
-    ref.current.addEventListener('vaChange', (e: CustomEvent) => {
-      helpers.setValue((e?.target as HTMLInputElement).checked);
-    });
-    // ESlint wants to set helpers as a useEffect dependency, but that'll add a
-    // _bunch_ of new event listeners. We only need the one.
-    //
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  useEffect(() => {
-    // @ts-ignore
-    ref.current.addEventListener('vaBlur', field.onBlur);
-  }, [field.onBlur]);
-
-  // TODO: Try using the <ErrorMessage> component
   return (
-    // @ts-ignore
-    <va-checkbox
-      ref={ref}
-      {...props}
+    <VaCheckbox
+      id={id}
+      label={props.label}
+      required={!!props.required}
       {...field}
+      onVaChange={(e: CustomEvent) => {
+        helpers.setValue((e?.target as HTMLInputElement).checked);
+      }}
       error={(meta.touched && meta.error) || undefined}
     />
   );
-};
-
-const CheckboxField = (props: CheckboxProps): JSX.Element => {
-  const id = props.id || props.name;
-  const validate = (value: string) => {
-    if (props.required && !value) {
-      const errorMessage =
-        typeof props.required === 'string'
-          ? props.required
-          : getMessage('required.default');
-      return errorMessage;
-    }
-
-    return props.validate ? props.validate(value) : undefined;
-  };
-  return <Wrapper id={id} {...props} validate={validate} />;
 };
 
 export default CheckboxField;

--- a/src/form-builder/CheckboxField.tsx
+++ b/src/form-builder/CheckboxField.tsx
@@ -20,6 +20,7 @@ const CheckboxField = (props: CheckboxProps): JSX.Element => {
       label={props.label}
       required={!!props.required}
       {...field}
+      checked={field.value}
       onVaChange={(e: CustomEvent) => {
         helpers.setValue((e?.target as HTMLInputElement).checked);
       }}

--- a/src/form-builder/CheckboxField.tsx
+++ b/src/form-builder/CheckboxField.tsx
@@ -13,7 +13,6 @@ const CheckboxField = (props: CheckboxProps): JSX.Element => {
     withValidation as FieldHookConfig<boolean>
   );
   const id = props.id || props.name;
-  console.log(field);
 
   return (
     <VaCheckbox

--- a/src/form-builder/SelectField.tsx
+++ b/src/form-builder/SelectField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
 
 import { FieldProps } from './types';

--- a/src/form-builder/TextField.tsx
+++ b/src/form-builder/TextField.tsx
@@ -1,52 +1,25 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import { useField, FieldHookConfig } from 'formik';
 
 import { FieldProps } from './types';
-import { getMessage } from '../utils/i18n';
+import { validator } from '../utils/validation';
+import { VaTextInput } from 'web-components/react-bindings';
 
-// TODO: Figure out how to actually import the type defintions for these web components
-// The @ts-ignore comments are because the web component types aren't available.
-const Wrapper = (props: FieldProps<string>) => {
-  const [field, meta] = useField(props as FieldHookConfig<string>);
+const TextField = (props: FieldProps<string>): JSX.Element => {
+  const withValidation = { ...props, validate: validator(props) };
+  const [field, meta] = useField(withValidation as FieldHookConfig<string>);
+  const id = props.id || props.name;
 
-  // TODO: Use the web component type
-  const ref = useRef<HTMLElement>(null);
-  useEffect(() => {
-    // @ts-ignore
-    ref.current.addEventListener('vaChange', field.onChange);
-  }, [field.onChange]);
-  useEffect(() => {
-    // @ts-ignore
-    ref.current.addEventListener('vaBlur', field.onBlur);
-  }, [field.onBlur]);
-
-  // TODO: Try using the <ErrorMessage> component
   return (
-    // @ts-ignore
-    <va-text-input
-      ref={ref}
-      {...props}
+    <VaTextInput
+      id={id}
+      label={props.label}
+      required={!!props.required}
       {...field}
+      onVaChange={field.onChange}
       error={(meta.touched && meta.error) || undefined}
     />
   );
-};
-
-const TextField = (props: FieldProps<string>): JSX.Element => {
-  const id = props.id || props.name;
-  const validate = (value: string) => {
-    if (props.required && !value) {
-      const errorMessage =
-        typeof props.required === 'string'
-          ? props.required
-          : getMessage('required.default');
-      return errorMessage;
-    }
-
-    return props.validate ? props.validate(value) : undefined;
-  };
-  return <Wrapper id={id} {...props} validate={validate} />;
 };
 
 export default TextField;

--- a/test/form-builder/CheckboxField.test.tsx
+++ b/test/form-builder/CheckboxField.test.tsx
@@ -6,8 +6,8 @@ import { buildRenderForm, changeValue } from '../utils';
 
 const renderForm = buildRenderForm({ thing: false });
 
-const getInput = (container: HTMLElement) => {
-  const input = container.querySelector('va-checkbox') as HTMLInputElement;
+const getInput = (container: HTMLElement): HTMLVaCheckboxElement => {
+  const input = container.querySelector('va-checkbox') as HTMLVaCheckboxElement;
   if (!input) throw new Error('No va-checkbox found');
   return input;
 };

--- a/test/form-builder/TextField.test.tsx
+++ b/test/form-builder/TextField.test.tsx
@@ -9,8 +9,10 @@ import { buildRenderForm, changeValue } from '../utils';
 
 const renderForm = buildRenderForm({});
 
-const getInput = (container: HTMLElement): HTMLInputElement => {
-  const input = container.querySelector('va-text-input') as HTMLInputElement;
+const getInput = (container: HTMLElement): HTMLVaTextInputElement => {
+  const input = container.querySelector(
+    'va-text-input'
+  ) as HTMLVaTextInputElement;
   if (!input) throw new Error('No va-text-input found');
   return input;
 };


### PR DESCRIPTION
Closes #7 

Use the React bindings for `TextField` and `CheckboxField`.