### PR TITLE
Get locally-linked packages to work

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -56,6 +56,8 @@ const config = {
         __dirname,
         '../src'
       ),
+      // So npm- / yarn-linked packages don't give us a hooks problem
+      react: path.resolve(__dirname, '../node_modules/react/'),
     },
   },
   plugins: [new CleanWebpackPlugin()],


### PR DESCRIPTION
Use webpack module resolution to get `yarn link`ed packages to not use two versions of `React` (which will, of course, break things).