### PR TITLE
master branch fix for formulate-testing

### DIFF
--- a/.github/workflows/formulate-testing.yml
+++ b/.github/workflows/formulate-testing.yml
@@ -2,9 +2,9 @@ name: Formulate Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
This repository has "master" and not "main" so need to update this in the Formulate-testing action to make it available