### PR TITLE
using yarn npm publish to allow tolerate-republish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,8 @@ name: Yarn publish
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   publish:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,6 @@ jobs:
       run: yarn build
     
     - name: Publish build artifacts to NPM
-      run: yarn npm publish --access public --tolerate-republish
+      run: yarn npm publish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,6 @@ jobs:
       run: yarn build
     
     - name: Publish build artifacts to NPM
-      run: yarn npm publish --access public
+      run: yarn npm publish --access public --tolerate-republish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,8 +3,6 @@ name: Yarn publish
 on:
   release:
     types: [published]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   publish:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,6 @@ jobs:
       run: yarn build
     
     - name: Publish build artifacts to NPM
-      run: npm publish --access public --tolerate-republish
+      run: yarn npm publish --access public --tolerate-republish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}


### PR DESCRIPTION
We want the tolerate-republish flag to:
"Warn and exit when republishing an already existing version of a package"

adding yarn in from of the npm publish command